### PR TITLE
feat: 카테고리 목록 API 응답 구조 변경

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,180 @@
+-- =============================================================================
+-- ZTLOG Database Schema
+-- Database: MySQL 8.0
+-- Charset: utf8mb4 / Collation: utf8mb4_unicode_ci
+-- =============================================================================
+
+CREATE DATABASE IF NOT EXISTS ztlog
+    DEFAULT CHARACTER SET utf8mb4
+    DEFAULT COLLATE utf8mb4_unicode_ci;
+
+USE ztlog;
+
+-- =============================================================================
+-- 1. user_mst (사용자)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS user_mst
+(
+    USER_NO   BIGINT       NOT NULL AUTO_INCREMENT COMMENT '사용자 번호',
+    USER_ID   VARCHAR(100) NOT NULL COMMENT '사용자 ID',
+    USERNAME  VARCHAR(100) NOT NULL COMMENT '사용자명',
+    PASSWORD  VARCHAR(300) NOT NULL COMMENT '암호화된 비밀번호',
+    `GRANT`   VARCHAR(50)  NOT NULL COMMENT '권한 (ROLE_ADMIN 등)',
+    INP_DTTM  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록일시',
+    UPD_DTTM  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (USER_NO),
+    UNIQUE KEY uq_user_id (USER_ID)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '사용자 마스터';
+
+-- =============================================================================
+-- 2. cate_mst (카테고리)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS cate_mst
+(
+    CATE_NO       BIGINT      NOT NULL AUTO_INCREMENT COMMENT '카테고리 번호',
+    CATE_NM       VARCHAR(100) NOT NULL COMMENT '카테고리명',
+    CATE_DEPTH    INT          NOT NULL COMMENT '카테고리 깊이 (1: 최상위)',
+    DISP_ORD      INT          NOT NULL DEFAULT 0 COMMENT '표시 순서',
+    USE_YN        CHAR(1)      NOT NULL DEFAULT 'Y' COMMENT '사용 여부 (Y/N)',
+    INP_USER      VARCHAR(100) NULL COMMENT '등록자',
+    UPPER_CATE_NO BIGINT       NULL COMMENT '상위 카테고리 번호 (self-ref)',
+    INP_DTTM      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록일시',
+    UPD_DTTM      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (CATE_NO),
+    KEY idx_upper_cate_no (UPPER_CATE_NO)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '카테고리 마스터';
+
+-- =============================================================================
+-- 3. tags_mst (태그)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS tags_mst
+(
+    TAG_NO   BIGINT       NOT NULL AUTO_INCREMENT COMMENT '태그 번호',
+    TAG_NAME VARCHAR(100) NOT NULL COMMENT '태그명',
+    INP_DTTM DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록일시',
+    UPD_DTTM DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (TAG_NO),
+    UNIQUE KEY uq_tag_name (TAG_NAME)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '태그 마스터';
+
+-- =============================================================================
+-- 4. contents_mst (게시물)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS contents_mst
+(
+    CTNT_NO      BIGINT        NOT NULL AUTO_INCREMENT COMMENT '게시물 번호',
+    CTNT_TITLE   VARCHAR(500)  NOT NULL COMMENT '게시물 제목',
+    CTNT_SUBTITLE VARCHAR(500) NOT NULL COMMENT '게시물 부제목',
+    CATE_NO      BIGINT        NULL COMMENT '카테고리 번호',
+    INP_USER     VARCHAR(100)  NOT NULL COMMENT '등록자',
+    DELETED_YN   CHAR(1)       NOT NULL DEFAULT 'N' COMMENT '삭제 여부 (Y/N, Hibernate SoftDelete)',
+    INP_DTTM     DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록일시',
+    UPD_DTTM     DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (CTNT_NO),
+    KEY idx_cate_no (CATE_NO),
+    KEY idx_deleted_yn (DELETED_YN)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '게시물 마스터';
+
+-- =============================================================================
+-- 5. contents_dtl (게시물 상세)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS contents_dtl
+(
+    CTNT_NO    BIGINT       NOT NULL COMMENT '게시물 번호 (PK, FK → contents_mst)',
+    CTNT_TITLE VARCHAR(500) NOT NULL COMMENT '게시물 제목',
+    CTNT_BODY  LONGTEXT     NOT NULL COMMENT '게시물 본문',
+    CTNT_PATH  VARCHAR(500) NULL COMMENT '파일 경로',
+    CTNT_NAME  VARCHAR(300) NULL COMMENT '파일명',
+    CTNT_EXT   VARCHAR(20)  NULL COMMENT '파일 확장자',
+    INP_USER   VARCHAR(100) NOT NULL COMMENT '등록자',
+    PRIMARY KEY (CTNT_NO)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '게시물 상세 (1:1 with contents_mst via @MapsId)';
+
+-- =============================================================================
+-- 6. contents_tags (게시물-태그 연결)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS contents_tags
+(
+    TAG_NO  BIGINT NOT NULL COMMENT '태그 번호 (FK → tags_mst)',
+    CTNT_NO BIGINT NOT NULL COMMENT '게시물 번호 (FK → contents_mst)',
+    SORT    INT    NOT NULL DEFAULT 0 COMMENT '태그 표시 순서',
+    PRIMARY KEY (TAG_NO, CTNT_NO)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '게시물-태그 연결 (N:M)';
+
+-- =============================================================================
+-- 7. file_mst (파일)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS file_mst
+(
+    FILE_NO   BIGINT       NOT NULL AUTO_INCREMENT COMMENT '파일 번호',
+    FILE_PATH VARCHAR(500) NULL COMMENT 'S3 파일 URL',
+    FILE_NAME VARCHAR(300) NULL COMMENT '파일명',
+    FILE_EXT  VARCHAR(20)  NULL COMMENT '파일 확장자',
+    CTNT_NO   VARCHAR(50)  NULL COMMENT '연결된 게시물 번호',
+    INP_DTTM  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록일시',
+    UPD_DTTM  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (FILE_NO)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '파일 마스터 (S3 업로드 파일)';
+
+-- =============================================================================
+-- 8. contents_view_stats (게시물 누적 조회수)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS contents_view_stats
+(
+    CTNT_NO  BIGINT NOT NULL COMMENT '게시물 번호 (PK, FK → contents_mst)',
+    VIEW_CNT BIGINT NOT NULL DEFAULT 0 COMMENT '누적 조회수',
+    PRIMARY KEY (CTNT_NO)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '게시물 누적 조회수 통계';
+
+-- =============================================================================
+-- 9. contents_daily_stats (일별 조회수)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS contents_daily_stats
+(
+    STAT_DATE DATE   NOT NULL COMMENT '통계 날짜',
+    CTNT_NO   BIGINT NOT NULL COMMENT '게시물 번호 (FK → contents_mst)',
+    VIEW_CNT  INT    NOT NULL DEFAULT 0 COMMENT '해당 날짜 조회수',
+    PRIMARY KEY (STAT_DATE, CTNT_NO)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '일별 게시물 조회수 통계 (Google Search Console 기반)';
+
+-- =============================================================================
+-- 10. contents_cmmt_stats (게시물 댓글수)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS contents_cmmt_stats
+(
+    CTNT_NO  BIGINT   NOT NULL COMMENT '게시물 번호 (PK, FK → contents_mst)',
+    CMMT_CNT INT      NOT NULL DEFAULT 0 COMMENT '댓글 수 (Giscus 기반)',
+    INP_DTTM DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록일시',
+    UPD_DTTM DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (CTNT_NO)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  COMMENT = '게시물 댓글수 통계 (Giscus/GitHub Discussions 기반)';

--- a/ztlog-api/src/main/java/com/devlog/api/service/category/CategoryService.java
+++ b/ztlog-api/src/main/java/com/devlog/api/service/category/CategoryService.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -39,9 +39,8 @@ public class CategoryService {
     public List<CategoryResDto> getCategoryList() {
         List<Category> list = categoryRepository.findAllByUseYnIs(UseYN.Y);
         // 필터 - 리스트 최상위만 루트로 잡음, 재귀 호출해서 하위 depth를 채움
-        return list.stream()
-                .filter(category -> ObjectUtils.isEmpty(category.getUpperCategory()))
-                .map(CategoryResDto::of)
+        return list.stream().filter(category -> ObjectUtils.isEmpty(category.getUpperCategory()))
+                .map(category -> CategoryResDto.of(category, contentRepository::countByCategoryCateNo))
                 .collect(Collectors.toList());
     }
 
@@ -49,7 +48,7 @@ public class CategoryService {
      * 카테고리 게시물 목록 조회하기
      *
      * @param cateNo 카테고리 번호
-     * @param page  페이지 번호 (기본값 = 1)
+     * @param page   페이지 번호 (기본값 = 1)
      * @return 카테고리 게시물 리스트
      */
     public ContentListResDto getCategoryContentList(Integer cateNo, Integer page) {

--- a/ztlog-api/src/main/java/com/devlog/api/service/category/dto/CategoryResDto.java
+++ b/ztlog-api/src/main/java/com/devlog/api/service/category/dto/CategoryResDto.java
@@ -1,11 +1,13 @@
 package com.devlog.api.service.category.dto;
 
 import com.devlog.core.common.enumulation.UseYN;
+import com.devlog.core.common.utils.DateUtils;
 import com.devlog.core.entity.category.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Getter
@@ -27,26 +29,33 @@ public class CategoryResDto {
     @Schema(description = "전시 순서")
     private Integer dispOrd;
 
+    @Schema(description = "게시물 갯수")
+    private Integer ctntCount;
+
     @Schema(description = "사용 여부")
     private UseYN useYn;
 
     @Schema(description = "생성자")
     private String inpUser;
 
+    @Schema(description = "생성일시")
+    private String inpDttm;
+
     private List<CategoryResDto> categories;
 
-    public static CategoryResDto of(Category category) {
+    public static CategoryResDto of(Category category, Function<Long, Integer> countProvider) {
         return CategoryResDto.builder()
                 .cateNo(category.getCateNo())
                 .cateNm(category.getCateNm())
                 .cateDepth(category.getCateDepth())
                 .dispOrd(category.getDispOrd())
+                .ctntCount(countProvider.apply(category.getCateNo()))
                 .useYn(category.getUseYn())
                 .inpUser(category.getInpUser())
-                .categories(category.getCategories().stream() // 자식들을 다시 DTO로 변환
-                        .map(CategoryResDto::of)
+                .inpDttm(DateUtils.datetomeToString(category.getInpDttm()))
+                .categories(category.getCategories().stream()
+                        .map(child -> of(child, countProvider))
                         .collect(Collectors.toList()))
                 .build();
     }
-
 }

--- a/ztlog-api/src/main/java/com/devlog/api/service/category/dto/CategoryResDto.java
+++ b/ztlog-api/src/main/java/com/devlog/api/service/category/dto/CategoryResDto.java
@@ -38,8 +38,8 @@ public class CategoryResDto {
     @Schema(description = "생성자")
     private String inpUser;
 
-    @Schema(description = "생성일시")
-    private String inpDttm;
+    @Schema(description = "수정일시")
+    private String updDttm;
 
     private List<CategoryResDto> categories;
 
@@ -52,7 +52,7 @@ public class CategoryResDto {
                 .ctntCount(countProvider.apply(category.getCateNo()))
                 .useYn(category.getUseYn())
                 .inpUser(category.getInpUser())
-                .inpDttm(DateUtils.datetomeToString(category.getInpDttm()))
+                .updDttm(DateUtils.datetomeToString(category.getUpdDttm()))
                 .categories(category.getCategories().stream()
                         .map(child -> of(child, countProvider))
                         .collect(Collectors.toList()))

--- a/ztlog-core/src/main/java/com/devlog/core/repository/content/ContentRepository.java
+++ b/ztlog-core/src/main/java/com/devlog/core/repository/content/ContentRepository.java
@@ -15,4 +15,6 @@ public interface ContentRepository extends JpaRepository<Content, Long>, Content
 
     Page<Content> findAllByCategoryCateNo(Long categoryCateNo, Pageable pageable);
 
+    Integer countByCategoryCateNo(Long categoryCateNo);
+
 }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                  
  - `GET /front/api/v1/categories` 응답에 카테고리별 게시물 수(`ctntCount`) 추가                                                                                                                                                                                                              
  - `CategoryResDto.of`에 `Function<Long, Integer>` count provider 도입으로 계층 구조의 각 카테고리가 독립적으로 게시물 수를 조회                                                                                                                                                             
  - `ContentRepository.countByCategoryCateNo` 기존 메서드 활용            
  - DB 스키마 파일 추가                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                              
  ## Changes      
  - `CategoryResDto`: `of(Category, int)` → `of(Category, Function<Long, Integer>)` 시그니처 변경, 재귀 호출 시 각 자식 카테고리에 count provider 전파
  - `CategoryService`: `contentRepository::countByCategoryCateNo` 메서드 레퍼런스 전달